### PR TITLE
Add CSS filter support.

### DIFF
--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -80,6 +80,7 @@ import {boxShadow} from './property-descriptors/box-shadow';
 import {paintOrder} from './property-descriptors/paint-order';
 import {webkitTextStrokeColor} from './property-descriptors/webkit-text-stroke-color';
 import {webkitTextStrokeWidth} from './property-descriptors/webkit-text-stroke-width';
+import {filter} from './property-descriptors/filter';
 import {Context} from '../core/context';
 
 export class CSSParsedDeclaration {
@@ -111,6 +112,7 @@ export class CSSParsedDeclaration {
     color: Color;
     direction: ReturnType<typeof direction.parse>;
     display: ReturnType<typeof display.parse>;
+    filter: ReturnType<typeof filter.parse>;
     float: ReturnType<typeof float.parse>;
     fontFamily: ReturnType<typeof fontFamily.parse>;
     fontSize: LengthPercentage;
@@ -180,6 +182,7 @@ export class CSSParsedDeclaration {
         this.color = parse(context, color, declaration.color);
         this.direction = parse(context, direction, declaration.direction);
         this.display = parse(context, display, declaration.display);
+        this.filter = parse(context, filter, declaration.filter);
         this.float = parse(context, float, declaration.cssFloat);
         this.fontFamily = parse(context, fontFamily, declaration.fontFamily);
         this.fontSize = parse(context, fontSize, declaration.fontSize);

--- a/src/css/property-descriptors/filter.ts
+++ b/src/css/property-descriptors/filter.ts
@@ -1,0 +1,42 @@
+import {IPropertyListDescriptor, PropertyDescriptorParsingType} from '../IPropertyDescriptor';
+import {CSSValue, isIdentWithValue, CSSFunction, isCSSFunction} from '../syntax/parser';
+import {isLength, Length} from '../types/length';
+import {Context} from "../../core/context";
+
+export type Filter = FilterItem[];
+export interface FilterItem {
+    name: string;
+    value: Length;
+}
+
+export const filter: IPropertyListDescriptor<Filter | null> = {
+    name: 'filter',
+    initialValue: 'none',
+    prefix: true,
+    type: PropertyDescriptorParsingType.LIST,
+    parse: (_context: Context, tokens: CSSValue[]) => {
+        if (tokens.length === 1 && isIdentWithValue(tokens[0], 'none')) {
+            return null;
+        }
+
+        const filter: Filter = [];
+
+        let hasFilter: boolean = false;
+
+        tokens.filter(isCSSFunction).forEach((token: CSSFunction) => {
+            for (let index = 0; index < token.values.length; index++) {
+                const value: CSSValue = token.values[index];
+                if (isLength(value)) {
+                    hasFilter = true;
+                    filter.push({name: token.name, value: value});
+                }
+            }
+        });
+
+        if (hasFilter) {
+            return filter;
+        } else {
+            return null;
+        }
+    }
+};

--- a/src/css/syntax/parser.ts
+++ b/src/css/syntax/parser.ts
@@ -147,6 +147,7 @@ export const isIdentToken = (token: CSSValue): token is StringValueToken => toke
 export const isStringToken = (token: CSSValue): token is StringValueToken => token.type === TokenType.STRING_TOKEN;
 export const isIdentWithValue = (token: CSSValue, value: string): boolean =>
     isIdentToken(token) && token.value === value;
+export const isCSSFunction = (token: CSSValue): token is CSSFunction => token.type === TokenType.FUNCTION;
 
 export const nonWhiteSpace = (token: CSSValue): boolean => token.type !== TokenType.WHITESPACE_TOKEN;
 export const nonFunctionArgSeparator = (token: CSSValue): boolean =>

--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -24,7 +24,14 @@ import {contentBox} from '../box-sizing';
 import {CanvasElementContainer} from '../../dom/replaced-elements/canvas-element-container';
 import {SVGElementContainer} from '../../dom/replaced-elements/svg-element-container';
 import {ReplacedElementContainer} from '../../dom/replaced-elements';
-import {EffectTarget, IElementEffect, isClipEffect, isOpacityEffect, isTransformEffect} from '../effects';
+import {
+    EffectTarget,
+    IElementEffect,
+    isClipEffect,
+    isFilterEffect,
+    isOpacityEffect,
+    isTransformEffect
+} from '../effects';
 import {contains} from '../../core/bitwise';
 import {calculateGradientDirection, calculateRadius, processColorStops} from '../../css/types/functions/gradient';
 import {FIFTY_PERCENT, getAbsoluteValue} from '../../css/types/length-percentage';
@@ -97,6 +104,12 @@ export class CanvasRenderer extends Renderer {
         this.ctx.save();
         if (isOpacityEffect(effect)) {
             this.ctx.globalAlpha = effect.opacity;
+        }
+
+        if (isFilterEffect(effect) && isSupportedFilter(this.ctx)) {
+            this.ctx.filter = effect.filter.map((item) =>
+                `${item.name}(${item.value.number}${('unit' in item.value) ? item.value.unit : ''})`
+            ).join(' ');
         }
 
         if (isTransformEffect(effect)) {
@@ -993,3 +1006,5 @@ const fixIOSSystemFonts = (fontFamilies: string[]): string[] => {
         ? fontFamilies.filter((fontFamily) => iOSBrokenFonts.indexOf(fontFamily) === -1)
         : fontFamilies;
 };
+
+const isSupportedFilter = (ctx: CanvasRenderingContext2D) => 'filter' in ctx;

--- a/src/render/effects.ts
+++ b/src/render/effects.ts
@@ -1,10 +1,12 @@
+import {FilterItem} from '../css/property-descriptors/filter';
 import {Matrix} from '../css/property-descriptors/transform';
 import {Path} from './path';
 
 export const enum EffectType {
     TRANSFORM = 0,
     CLIP = 1,
-    OPACITY = 2
+    OPACITY = 2,
+    FILTER = 3
 }
 
 export const enum EffectTarget {
@@ -44,7 +46,15 @@ export class OpacityEffect implements IElementEffect {
     constructor(readonly opacity: number) {}
 }
 
+export class FilterEffect implements IElementEffect {
+    readonly type: EffectType = EffectType.FILTER;
+    readonly target: number = EffectTarget.BACKGROUND_BORDERS | EffectTarget.CONTENT;
+
+    constructor(readonly filter: FilterItem[]) {}
+}
+
 export const isTransformEffect = (effect: IElementEffect): effect is TransformEffect =>
     effect.type === EffectType.TRANSFORM;
 export const isClipEffect = (effect: IElementEffect): effect is ClipEffect => effect.type === EffectType.CLIP;
 export const isOpacityEffect = (effect: IElementEffect): effect is OpacityEffect => effect.type === EffectType.OPACITY;
+export const isFilterEffect = (effect: IElementEffect): effect is FilterEffect => effect.type === EffectType.FILTER;

--- a/src/render/stacking-context.ts
+++ b/src/render/stacking-context.ts
@@ -1,7 +1,15 @@
 import {ElementContainer, FLAGS} from '../dom/element-container';
 import {contains} from '../core/bitwise';
 import {BoundCurves, calculateBorderBoxPath, calculatePaddingBoxPath} from './bound-curves';
-import {ClipEffect, EffectTarget, IElementEffect, isClipEffect, OpacityEffect, TransformEffect} from './effects';
+import {
+    ClipEffect,
+    EffectTarget,
+    FilterEffect,
+    IElementEffect,
+    isClipEffect,
+    OpacityEffect,
+    TransformEffect
+} from './effects';
 import {OVERFLOW} from '../css/property-descriptors/overflow';
 import {equalPath} from './path';
 import {DISPLAY} from '../css/property-descriptors/display';
@@ -44,6 +52,9 @@ export class ElementPaint {
         this.curves = new BoundCurves(this.container);
         if (this.container.styles.opacity < 1) {
             this.effects.push(new OpacityEffect(this.container.styles.opacity));
+        }
+        if (this.container.styles.filter && this.container.styles.filter.length) {
+            this.effects.push(new FilterEffect(this.container.styles.filter));
         }
 
         if (this.container.styles.transform !== null) {


### PR DESCRIPTION
Canvas context has native [filter](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/filter) support. This PR should fix mismatch on elements with CSS filter.
